### PR TITLE
Removed .import from ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 
 # Godot-specific ignores
 .import/
-*.import
 export.cfg
 export_presets.cfg
 


### PR DESCRIPTION
This change was leftover from a cleanup.

We deffo want to have .imports pushed