### PR TITLE
Allow wall dropoff

### DIFF
--- a/Moonshot/player/LedgeWallDetector.gd
+++ b/Moonshot/player/LedgeWallDetector.gd
@@ -3,10 +3,9 @@ extends Position2D
 # Detects ledges using two Raycasts casting horizontally.
 # If one ray is in a wall and the other is in the air, it means the node is near a ledge.
 
-
-onready var ray_bottom: RayCast2D = $RayBottom
-onready var ray_middle: RayCast2D = $RayMiddle
 onready var ray_top: RayCast2D = $RayTop
+onready var ray_middle: RayCast2D = $RayMiddle
+onready var ray_bottom: RayCast2D = $RayBottom
 
 export var is_active := true
 

--- a/Moonshot/player/LedgeWallDetector.gd
+++ b/Moonshot/player/LedgeWallDetector.gd
@@ -5,6 +5,7 @@ extends Position2D
 
 
 onready var ray_bottom: RayCast2D = $RayBottom
+onready var ray_middle: RayCast2D = $RayMiddle
 onready var ray_top: RayCast2D = $RayTop
 
 export var is_active := true
@@ -12,6 +13,7 @@ export var is_active := true
 
 func _ready():
 	assert(ray_top.cast_to.x >= 0)
+	assert(ray_middle.cast_to.x >= 0)
 	assert(ray_bottom.cast_to.x >= 0)
 
 
@@ -23,20 +25,32 @@ func _unhandled_input(event: InputEvent) -> void:
 
 
 func is_against_ledge() -> bool:
-	return is_active and ray_bottom.is_colliding() and not ray_top.is_colliding()
+	return is_active and ray_bottom.is_colliding() and not ray_middle.is_colliding() and not ray_top.is_colliding()
 
 
 func is_against_wall() -> bool:
-	return is_active and (ray_bottom.is_colliding() or ray_top.is_colliding())
+	return is_active and  ray_top.is_colliding()
+
+
+func is_hanging() -> bool:
+	return is_active and (not ray_middle.is_colliding() and not ray_bottom.is_colliding()) and ray_top.is_colliding()
+
+
+func is_at_step() -> bool:
+	return is_active and ray_bottom.is_colliding() and ray_middle.is_colliding() and not ray_top.is_colliding()
 
 
 func get_cast_to_directed() -> Vector2:
-	return Vector2(ray_top.cast_to.x * scale.x, 0.0)
+	return Vector2(ray_middle.cast_to.x * scale.x, 0.0)
 
 
 func get_top_global_position() -> Vector2:
 	return ray_top.global_position
 
 
+func get_mid_global_position() -> Vector2:
+	return ray_middle.global_position
+
+
 func get_ray_length() -> float:
-	return ray_top.cast_to.x
+	return ray_middle.cast_to.x

--- a/Moonshot/player/LedgeWallDetector.tscn
+++ b/Moonshot/player/LedgeWallDetector.tscn
@@ -2,19 +2,22 @@
 
 [ext_resource path="res://player/LedgeWallDetector.gd" type="Script" id=1]
 
-[node name="LedeWallDetector" type="Position2D"]
+[node name="LedgeWallDetector" type="Position2D"]
 script = ExtResource( 1 )
 
 [node name="RayBottom" type="RayCast2D" parent="."]
-position = Vector2( 24, 0 )
 enabled = true
-exclude_parent = false
 cast_to = Vector2( 20, 0 )
-collision_mask = 2
+collide_with_areas = true
+
+[node name="RayMiddle" type="RayCast2D" parent="."]
+position = Vector2( 0, -10 )
+enabled = true
+cast_to = Vector2( 20, 0 )
+collide_with_areas = true
 
 [node name="RayTop" type="RayCast2D" parent="."]
-position = Vector2( 24, -35 )
+position = Vector2( 0, -45 )
 enabled = true
-exclude_parent = false
 cast_to = Vector2( 20, 0 )
-collision_mask = 2
+collide_with_areas = true

--- a/Moonshot/player/States/air.gd
+++ b/Moonshot/player/States/air.gd
@@ -32,15 +32,14 @@ func physics_process(delta: float) -> void:
 	_parent.physics_process(delta)
 	Events.emit_signal("player_moved", owner)
 
+	var ld = owner.ledge_wall_detector
+
 	# Landing
 	if owner.is_on_floor():
 		var target_state := "Move/Idle" if _parent.get_move_direction().x == 0 else "Move/Run"
 		_state_machine.transition_to(target_state)
 
-	elif owner.ledge_wall_detector.is_against_ledge():
-		_state_machine.transition_to("Ledge", {move_state = _parent})
-
-	if owner.is_on_wall():
+	elif owner.is_on_wall() and ld.is_against_wall() and not ld.is_hanging():
 		var wall_normal: float = owner.get_slide_collision(0).normal.x
 		_state_machine.transition_to("Move/Wall", {"normal": wall_normal, "velocity": _parent.velocity})
 

--- a/Moonshot/player/States/air.gd
+++ b/Moonshot/player/States/air.gd
@@ -39,6 +39,7 @@ func physics_process(delta: float) -> void:
 		var target_state := "Move/Idle" if _parent.get_move_direction().x == 0 else "Move/Run"
 		_state_machine.transition_to(target_state)
 
+	# Wall hanging dropoff
 	elif owner.is_on_wall() and ld.is_against_wall() and not ld.is_hanging():
 		var wall_normal: float = owner.get_slide_collision(0).normal.x
 		_state_machine.transition_to("Move/Wall", {"normal": wall_normal, "velocity": _parent.velocity})

--- a/Moonshot/player/States/air.gd
+++ b/Moonshot/player/States/air.gd
@@ -39,7 +39,7 @@ func physics_process(delta: float) -> void:
 		var target_state := "Move/Idle" if _parent.get_move_direction().x == 0 else "Move/Run"
 		_state_machine.transition_to(target_state)
 
-	# Wall hanging dropoff
+	# Grab Wall
 	elif owner.is_on_wall() and ld.is_against_wall() and not ld.is_hanging():
 		var wall_normal: float = owner.get_slide_collision(0).normal.x
 		_state_machine.transition_to("Move/Wall", {"normal": wall_normal, "velocity": _parent.velocity})

--- a/Moonshot/player/States/ledge.gd
+++ b/Moonshot/player/States/ledge.gd
@@ -2,20 +2,15 @@ extends State
 # Pulls the character up a ledge, temporarily taking control away from the player
 
 
-func _on_Skin_animation_finished(name: String) -> void:
-	if name == "ledge":
-		_state_machine.transition_to("Move/Run")
-
-
 func enter(msg: Dictionary = {}) -> void:
 	assert("move_state" in msg and msg.move_state is State)
-	
 	var start: Vector2 = owner.global_position
 	var ld = owner.ledge_wall_detector
-	owner.global_position = ld.get_top_global_position() + ld.get_cast_to_directed()
+	owner.global_position = ld.get_mid_global_position() + ld.get_cast_to_directed()
 	owner.global_position = owner.floor_detector.get_floor_position()
 	msg.move_state.velocity.y = 0.0
-
+	_state_machine.transition_to("Move/Run")
 
 func exit() -> void:
 	pass
+

--- a/Moonshot/player/States/move.gd
+++ b/Moonshot/player/States/move.gd
@@ -4,9 +4,10 @@ extends State
 
 const PASS_THROUGH_LAYER = 3
 
+# These values allow for 5 block jump.
 export var max_speed_default := Vector2(500.0, 1500.0)
-export var acceleration_default := Vector2(10000, 3000.0)
-export var jump_impulse := 1050.0
+export var acceleration_default := Vector2(5000, 3000.0)
+export var jump_impulse := 1010.0
 
 var acceleration := acceleration_default
 var max_speed := max_speed_default

--- a/Moonshot/player/States/wall.gd
+++ b/Moonshot/player/States/wall.gd
@@ -25,14 +25,19 @@ func physics_process(delta: float) -> void:
 	_velocity.y = clamp(_velocity.y, -max_slide_speed, max_slide_speed)
 	_velocity = owner.move_and_slide_with_snap(_velocity, Vector2(-_wall_normal, 0), owner.FLOOR_NORMAL)
 
+	var ld = owner.ledge_wall_detector
+	var is_moving_away_from_wall := sign(_parent.get_move_direction().x) == sign(_wall_normal)
+
 	if owner.is_on_floor():
 		_state_machine.transition_to("Move/Idle")
 
-	var is_moving_away_from_wall := sign(_parent.get_move_direction().x) == sign(_wall_normal)
-	if is_moving_away_from_wall:
-		_state_machine.transition_to("Move/Air", {"velocity":_velocity})
+	elif is_moving_away_from_wall:
+		_state_machine.transition_to("Move/Air", {"velocity": _velocity})
 
-	if owner.ledge_wall_detector.is_against_ledge():
+	elif ld.is_hanging():
+		_state_machine.transition_to("Move/Air", {"velocity": _velocity})
+
+	elif ld.is_against_ledge():
 		_state_machine.transition_to("Ledge", {move_state = _parent})
 
 

--- a/Moonshot/player/States/wall.gd
+++ b/Moonshot/player/States/wall.gd
@@ -34,6 +34,7 @@ func physics_process(delta: float) -> void:
 	elif is_moving_away_from_wall:
 		_state_machine.transition_to("Move/Air", {"velocity": _velocity})
 
+	# Drop player if they are hanging by top portion of body only
 	elif ld.is_hanging():
 		_state_machine.transition_to("Move/Air", {"velocity": _velocity})
 

--- a/Moonshot/player/player.tscn
+++ b/Moonshot/player/player.tscn
@@ -45,25 +45,25 @@ animations = [ {
 "name": "idle",
 "speed": 5.0
 }, {
-"frames": [ ExtResource( 27 ), ExtResource( 28 ), ExtResource( 23 ), ExtResource( 26 ), ExtResource( 22 ), ExtResource( 21 ), ExtResource( 24 ), ExtResource( 25 ), ExtResource( 29 ), ExtResource( 30 ) ],
+"frames": [ ExtResource( 23 ), ExtResource( 26 ), ExtResource( 22 ), ExtResource( 21 ), ExtResource( 24 ), ExtResource( 25 ), ExtResource( 29 ), ExtResource( 30 ), ExtResource( 27 ), ExtResource( 28 ) ],
 "loop": true,
 "name": "run",
 "speed": 15.0
-}, {
-"frames": [ ExtResource( 27 ), ExtResource( 28 ), ExtResource( 23 ), ExtResource( 26 ), ExtResource( 22 ), ExtResource( 21 ), ExtResource( 24 ), ExtResource( 25 ), ExtResource( 29 ), ExtResource( 30 ) ],
-"loop": true,
-"name": "spawn",
-"speed": 5.0
 }, {
 "frames": [ ExtResource( 30 ) ],
 "loop": false,
 "name": "wall",
 "speed": 0.0
 }, {
+"frames": [ ExtResource( 31 ), ExtResource( 34 ), ExtResource( 33 ), ExtResource( 32 ) ],
+"loop": true,
+"name": "die",
+"speed": 8.0
+}, {
 "frames": [ ExtResource( 27 ), ExtResource( 28 ), ExtResource( 23 ), ExtResource( 26 ), ExtResource( 22 ), ExtResource( 21 ), ExtResource( 24 ), ExtResource( 25 ), ExtResource( 29 ), ExtResource( 30 ) ],
 "loop": true,
-"name": "debug",
-"speed": 5.0
+"name": "ledge",
+"speed": 100.0
 }, {
 "frames": [ ExtResource( 27 ), ExtResource( 28 ), ExtResource( 23 ), ExtResource( 26 ), ExtResource( 22 ), ExtResource( 21 ), ExtResource( 24 ), ExtResource( 25 ), ExtResource( 29 ), ExtResource( 30 ) ],
 "loop": true,
@@ -72,13 +72,13 @@ animations = [ {
 }, {
 "frames": [ ExtResource( 27 ), ExtResource( 28 ), ExtResource( 23 ), ExtResource( 26 ), ExtResource( 22 ), ExtResource( 21 ), ExtResource( 24 ), ExtResource( 25 ), ExtResource( 29 ), ExtResource( 30 ) ],
 "loop": true,
-"name": "ledge",
-"speed": 100.0
+"name": "spawn",
+"speed": 5.0
 }, {
-"frames": [ ExtResource( 31 ), ExtResource( 34 ), ExtResource( 33 ), ExtResource( 32 ) ],
+"frames": [ ExtResource( 27 ), ExtResource( 28 ), ExtResource( 23 ), ExtResource( 26 ), ExtResource( 22 ), ExtResource( 21 ), ExtResource( 24 ), ExtResource( 25 ), ExtResource( 29 ), ExtResource( 30 ) ],
 "loop": true,
-"name": "die",
-"speed": 8.0
+"name": "debug",
+"speed": 5.0
 } ]
 
 [sub_resource type="SpriteFrames" id=3]
@@ -92,7 +92,8 @@ animations = [ {
 [node name="Player" type="KinematicBody2D" groups=[
 "Player",
 ]]
-collision_mask = 14
+collision_layer = 2
+collision_mask = 13
 script = ExtResource( 14 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -102,6 +103,7 @@ shape = SubResource( 1 )
 [node name="LedgeWallDetector" parent="." instance=ExtResource( 5 )]
 
 [node name="FloorDetector" parent="." instance=ExtResource( 3 )]
+collision_mask = 9
 
 [node name="PassThrough" parent="." instance=ExtResource( 7 )]
 
@@ -130,7 +132,6 @@ one_shot = true
 
 [node name="Air" type="Node" parent="StateMachine/Move"]
 script = ExtResource( 19 )
-acceleration_x = 5000.0
 
 [node name="JumpDelay" type="Timer" parent="StateMachine/Move/Air"]
 wait_time = 0.1


### PR DESCRIPTION
Houston, we have lift off (from walls).

Fixed a load of problems with this pull.

Have a new, 3rd RayCast2D, whch gives much more flexibilty in determining the state of the player. No longer flips between Wall and Air (running 1 physics_process per flip) at any transition or state that I have tested!!

Have removed Air -> Ledge transitions which has done mad improvements for the maneuvering around single 32px block height increases. 

