### PR TITLE
Player variable jumps and air resistance

### DIFF
--- a/Moonshot/player/States/air.gd
+++ b/Moonshot/player/States/air.gd
@@ -16,7 +16,7 @@ onready var jump_delay: Timer = $JumpDelay
 onready var controls_freeze: Timer = $ControlsFreeze
 
 export var acceleration_x := 2500.0
-
+export var jump_deceleration := 5000.0
 
 func unhandled_input(event: InputEvent) -> void:
 	# Jump after falling off a ledge
@@ -30,6 +30,11 @@ func unhandled_input(event: InputEvent) -> void:
 
 func physics_process(delta: float) -> void:
 	_parent.physics_process(delta)
+
+	# Variable jump height.
+	if !Input.is_action_pressed("jump") and sign(_parent.velocity.y) == sign(Vector2.UP.y):
+		_parent.velocity.y += jump_deceleration * delta
+
 	Events.emit_signal("player_moved", owner)
 
 	var ld = owner.ledge_wall_detector

--- a/Moonshot/player/States/air.gd
+++ b/Moonshot/player/States/air.gd
@@ -17,6 +17,7 @@ onready var controls_freeze: Timer = $ControlsFreeze
 
 export var acceleration_x := 2500.0
 export var jump_deceleration := 5000.0
+export var air_resistance := 1250.0
 
 func unhandled_input(event: InputEvent) -> void:
 	# Jump after falling off a ledge
@@ -32,8 +33,11 @@ func physics_process(delta: float) -> void:
 	_parent.physics_process(delta)
 
 	# Variable jump height.
-	if !Input.is_action_pressed("jump") and sign(_parent.velocity.y) == sign(Vector2.UP.y):
+	if not Input.is_action_pressed("jump") and sign(_parent.velocity.y) == sign(Vector2.UP.y):
 		_parent.velocity.y += jump_deceleration * delta
+
+	if not Input.is_action_pressed("move_left") or not Input.is_action_pressed("move_left"):
+		_parent.velocity.x -= sign(_parent.velocity.x) * air_resistance * delta
 
 	Events.emit_signal("player_moved", owner)
 


### PR DESCRIPTION
This is a very small change. It actually feels really nice with this value (`jump_deceleration = 5000.0`), requiring you to hold jump to the peak to get max jump height. 

If you don't quite hold all the way it seems you only get a really tiny max height reached,

and so I am happy to merge this. It feels nice, please try it out. If we are happy we can merge, and then minor tweaks to it can be done after I get through other player features.

Edit: I also added the work for air resistance (set to `1250.0`). Air resistance will **not** apply on wall jumps, unless a horizontal  directional input is detected whilst in mid-air, and it will kick back in.