### PR TITLE
Increase player and arm Z index

### DIFF
--- a/Moonshot/player/player.tscn
+++ b/Moonshot/player/player.tscn
@@ -159,6 +159,7 @@ script = ExtResource( 18 )
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 position = Vector2( -0.0327721, -30.8946 )
 frames = SubResource( 2 )
+z_index = 2
 animation = "idle"
 frame = 1
 playing = true
@@ -176,6 +177,5 @@ position = Vector2( 28, 0 )
 
 [node name="AnimatedSprite" type="AnimatedSprite" parent="TurnAxis/CastPoint"]
 position = Vector2( 6.53168, 4.35445 )
-z_index = -1
 frames = SubResource( 3 )
 offset = Vector2( -16, -4 )


### PR DESCRIPTION
Arm was at Z = -1, which put it behind some objects. If we put it back to 0 it will be fixed. I have also put player at 2, so if we intentionally want to have the arm be hidden we have more space to order them (eg. maybe having walls at Z = 1)