### PR TITLE
Testing Spawn Fix

### DIFF
--- a/Moonshot/room_templates/BaseRoom.gd
+++ b/Moonshot/room_templates/BaseRoom.gd
@@ -2,6 +2,14 @@ extends Node2D
 
 signal indicate_room_change(exit_key, entrance)
 
+const MAIN_GAME : bool = false
+
+func _ready():
+	if get_tree().get_current_scene().MAIN_GAME == false:
+		self.add_child(Utils.Player)
+		Utils.Player.position = self.get_node("testing_player_spawn").position
+		self.setup_player_camera()
+
 
 func setup_player_camera():
 	# Set the player to have the camera


### PR DESCRIPTION
Some code was missing from `BaseRoom.gd` in the tile system beta to allow individual room testing.