### PR TITLE
(patch) Improved sprite alignment

### DIFF
--- a/Moonshot/player/player.tscn
+++ b/Moonshot/player/player.tscn
@@ -200,7 +200,7 @@ script = ExtResource( 16 )
 script = ExtResource( 18 )
 
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
-position = Vector2( -0.0327721, -30.8946 )
+position = Vector2( 0, -29 )
 z_index = 2
 frames = SubResource( 2 )
 animation = "stagger"


### PR DESCRIPTION
Slightly adjust player sprite to overlap the tile more.

<img width="118" alt="Godot_v3 2 3-stable_win64_2020-11-25_17-52-31" src="https://user-images.githubusercontent.com/18307819/100264923-634b6100-2f47-11eb-8918-a9ecad909611.png">
<img width="133" alt="Godot_v3 2 3-stable_win64_2020-11-25_17-53-20" src="https://user-images.githubusercontent.com/18307819/100264927-63e3f780-2f47-11eb-9f8d-70f5528f515d.png">


