### PR TITLE
(patch) reduce camera offsets

### DIFF
--- a/Moonshot/player/player.tscn
+++ b/Moonshot/player/player.tscn
@@ -207,6 +207,9 @@ animation = "stagger"
 playing = true
 
 [node name="Camera2D" parent="." instance=ExtResource( 6 )]
+drag_margin_left = 0.1
+drag_margin_top = 0.1
+drag_margin_right = 0.1
 
 [node name="Stats" parent="." instance=ExtResource( 8 )]
 


### PR DESCRIPTION
Lowered to 0.1 on each side, and bottom remains at zero.

This feels much more responsive in the maps I have tested it in.