### PR TITLE
(enhancement) tweaking gravity for nicer player feel

### DIFF
--- a/Moonshot/player/States/move.gd
+++ b/Moonshot/player/States/move.gd
@@ -8,8 +8,8 @@ const PASS_THROUGH_LAYER = 3
 
 # These values allow for 5 block jump.
 export var max_speed_default := Vector2(500.0, 1500.0)
-export var acceleration_default := Vector2(5000, 3000.0)
-export var jump_impulse := 1010.0
+export var acceleration_default := Vector2(3000.0, 2000.0)
+export var jump_impulse := 820.0
 
 var acceleration := acceleration_default
 var max_speed := max_speed_default

--- a/Moonshot/player/States/run.gd
+++ b/Moonshot/player/States/run.gd
@@ -3,31 +3,6 @@ extends State
 # Delegates movement to its parent Move state and extends it
 # with state transitions
 
-onready var slow_starter: Timer = $SlowStarter
-onready var tween: Tween = $Tween
-
-export var slow_duration_seconds := 0.4
-
-
-func _ready() -> void:
-# warning-ignore:return_value_discarded
-	slow_starter.connect("timeout", self, "_on_SlowDown_timeout")
-
-
-func _on_SlowDown_timeout() -> void:
-# warning-ignore:return_value_discarded
-	tween.interpolate_property(
-		_parent,
-		"max_speed",
-		_parent.max_speed,
-		_parent.max_speed_default,
-		slow_duration_seconds,
-		Tween.TRANS_LINEAR,
-		Tween.EASE_OUT
-	)
-# warning-ignore:return_value_discarded
-	tween.start()
-
 
 func unhandled_input(event: InputEvent) -> void:
 	_parent.unhandled_input(event)
@@ -44,8 +19,6 @@ func physics_process(delta: float) -> void:
 
 func enter(msg: Dictionary = {}) -> void:
 	_parent.enter(msg)
-	if not Utils.is_equal_approx(_parent.max_speed.x, _parent.max_speed_default.x):
-		slow_starter.start()
 
 
 func exit() -> void:

--- a/Moonshot/player/States/wall.gd
+++ b/Moonshot/player/States/wall.gd
@@ -7,7 +7,7 @@ export var slide_acceleration := 1600.0
 export var max_slide_speed := 200.0
 export (float, 0.0, 1.0) var friction_factor := 0.15
 
-export var jump_strength := Vector2(500.0, 900.0)
+export var jump_strength := Vector2(500.0, 650.0)
 var _wall_normal := -1
 var _velocity := Vector2.ZERO
 var wall_grace_counter = 0

--- a/Moonshot/player/player.tscn
+++ b/Moonshot/player/player.tscn
@@ -151,12 +151,6 @@ one_shot = true
 [node name="Run" type="Node" parent="StateMachine/Move"]
 script = ExtResource( 15 )
 
-[node name="SlowStarter" type="Timer" parent="StateMachine/Move/Run"]
-wait_time = 0.7
-one_shot = true
-
-[node name="Tween" type="Tween" parent="StateMachine/Move/Run"]
-
 [node name="Air" type="Node" parent="StateMachine/Move"]
 script = ExtResource( 19 )
 


### PR DESCRIPTION
Reduce acceleration.y, reduce jumps.y from floor and wall to account for this.

This is a significant change and you should test this out.
Much softer/floaty, fits in with the moon theme, and also allow for much more control on the player hopefully.

I have made sure that the Intern can reach the same height jumps that they could reach before this change, and the same distance, and so this shouldn't break any routes in your maps. 
