### PR TITLE
Fix: Minimap gui box filepath patch.

### DIFF
--- a/Moonshot/main_game.gd
+++ b/Moonshot/main_game.gd
@@ -30,7 +30,7 @@ func go_up_level():
 	current_room_node.get_node("Player").queue_free()
 	current_room_node.queue_free()
 	level_map.clear()
-	var minimap_gui_box = get_node('GUI/MarginContainer/VBoxContainer/MinimapBox/VBoxContainer2/HBoxContainer/MinimapBackground')
+	var minimap_gui_box = get_node('GUI/MinimapBox/MinimapBackground')
 	minimap.set_minimap_size(minimap_gui_box.rect_size / 2)
 	Utils.reset_player()
 	CombatSignalController.connect('player_kill', self, 'activate_death_screen')


### PR DESCRIPTION
![chrome_DGzJ2qz89b](https://user-images.githubusercontent.com/67764860/100598099-3061ee00-32f6-11eb-80a5-154fff39b41f.png)
![chrome_3z7whO1oUi](https://user-images.githubusercontent.com/67764860/100598103-322bb180-32f6-11eb-83fe-ceda7a6c8cb1.png)

Filepath was pointing to non existent node, crashing.